### PR TITLE
Add static to functions defined in library header.

### DIFF
--- a/include/libsupermesh-c.h
+++ b/include/libsupermesh-c.h
@@ -34,12 +34,12 @@ void libsupermesh_intersect_tri_quad(c_kind* tri_a, c_kind* quad_b, c_kind* tris
 }
 #endif
 
-int libsupermesh_max_n_tris_c(int n_lines_b, int n_lines_a){
+static int libsupermesh_max_n_tris_c(int n_lines_b, int n_lines_a){
    int out = n_lines_a*pow(2, n_lines_b) - 2;
    return out;
 }
 
-int libsupermesh_max_n_tets_c(int n_planes_b){
+static int libsupermesh_max_n_tets_c(int n_planes_b){
    int out = pow(3, n_planes_b);
    return out;
 }


### PR DESCRIPTION
Hello,

When including "libsupermesh-c.h" in several *.c files, the linker raises a "multiple definition" error for `libsupermesh_max_n_tris_c` and `libsupermesh_max_n_tets_c`. In fact these functions are defined (and not just declared) in the header, so they do get defined multiple times when the header is included in different *.c files.

This patch proposes to solve this by adding `static` keyword to restrict the visibility of these function only to the current translation unit.